### PR TITLE
Add char count and handle long messages

### DIFF
--- a/src/Sms.py
+++ b/src/Sms.py
@@ -311,11 +311,13 @@ class MessageWindow(Gtk.Window):
 		text_buffer = self.body.get_buffer()
 		start, end = text_buffer.get_bounds()
 		message = text_buffer.get_text(start, end, False)
-		subprocess.call([
-			'kdeconnect-cli',
-			'--device', args.device,
-			'--destination', phone,
-			'--send-sms', message])
+		chunks = (message[x:x+160] for x in range(0, len(message), 160))
+		for chunk in chunks:
+			subprocess.call([
+				'kdeconnect-cli',
+				'--device', args.device,
+				'--destination', phone,
+				'--send-sms', chunk])
 		self.close()
 
 MessageWindow()


### PR DESCRIPTION
Added character count and this brought to my attention the fact that `kdeconnect-cli`
quietly does nothing if message is longer than 160 chars.
Splitting long messages into 160 char chunks now.