### PR TITLE
Fix python3-requests-oauthlib dependency missing on openSUSE

### DIFF
--- a/rpm/_aggregate
+++ b/rpm/_aggregate
@@ -1,0 +1,5 @@
+<aggregatelist>
+  <aggregate project="devel:languages:python3">
+    <package>python3-requests-oauthlib</package>
+  </aggregate>
+</aggregatelist>

--- a/rpm/indicator-kdeconnect.spec
+++ b/rpm/indicator-kdeconnect.spec
@@ -57,6 +57,7 @@ Requires:       python3-requests-oauthlib
 BuildRequires:  update-desktop-files
 BuildRequires:  libappindicator3-devel
 Requires:       kdeconnect-kde
+Requires:       python3-requests-oauthlib
 %endif
 
 %description


### PR DESCRIPTION
Fixes https://github.com/Bajoja/indicator-kdeconnect/issues/71 

I have duly verified that installing the package python3-requests-oauthlib fixes the issue. But since I do not have an OBS dev setup the change for OBS was done only reading the OBS manual, I hope it works as is ;-)