### PR TITLE
No longer split long messages

### DIFF
--- a/src/sms/Sms.py
+++ b/src/sms/Sms.py
@@ -407,15 +407,15 @@ class MessageWindow(Gtk.Window):
 		text_buffer = self.body.get_buffer()
 		start, end = text_buffer.get_bounds()
 		message = text_buffer.get_text(start, end, False)
-		chunks = (message[x:x+160] for x in range(0, len(message), 160))
-		for chunk in chunks:
-			for phone in phones:
-				if not phone.isspace():
-					subprocess.call([
-						'kdeconnect-cli',
-						'--device', args.device,
-						'--destination', phone.strip(),
-						'--send-sms', chunk])
+		#~ chunks = (message[x:x+160] for x in range(0, len(message), 160))
+		#~ for chunk in chunks:
+		for phone in phones:
+			if not phone.isspace():
+				subprocess.call([
+					'kdeconnect-cli',
+					'--device', args.device,
+					'--destination', phone.strip(),
+					'--send-sms', message])
 		self.close()
 
 MessageWindow()


### PR DESCRIPTION
KDE Connect android app was recently updated to correctly handle sending of multi-part sms.
Splitting of long messages into separate sms is no longer needed and probably undesired.