### PR TITLE
Fix debianization

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,12 +3,15 @@ Section: net
 Priority: optional
 Maintainer: Bajoja <steevenlopes@outlook.com>
 Build-Depends: cmake (>= 2.8),
-               debhelper (>= 9.0.0),
+               debhelper (>= 10.3),
                libgtk-3-dev (>=3.6),
                libappindicator3-dev,
+               libgee-0.8-dev,
+               libjson-glib-dev,
                pkg-config,
                python3,
-               valac (>=0.20)
+               meson,
+               valac (>=0.40)
 Standards-Version: 4.1.1
 Homepage: https://github.com/Bajoja/indicator-kdeconnect
 Vcs-Browser: https://github.com/Bajoja/indicator-kdeconnect
@@ -16,7 +19,7 @@ Vcs-Git: https://github.com/Bajoja/indicator-kdeconnect.git
 
 Package: indicator-kdeconnect
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, ${python3:Depends}, python3-requests-oauthlib, kdeconnect
+Depends: ${misc:Depends}, ${shlibs:Depends}, ${python3:Depends}, python3-requests-oauthlib, kdeconnect (>=1.3.0)
 Suggests: python-nautilus, python-caja, python-nemo
 Description: Indicator for KDE Connect
  KDE Connect is a tool to integrate the KDE Plasma Workspace with your

--- a/debian/rules
+++ b/debian/rules
@@ -11,7 +11,3 @@
 
 %:
 	dh $@ --with python3
- 
-override_dh_auto_install:
-	dh_auto_install
-	chmod 755 debian/indicator-kdeconnect/usr/share/indicator-kdeconnect/Sms.py


### PR DESCRIPTION
Previously running `debuild` would fail to compile.  It now results in a
working package.