### PR TITLE
Fix incorrect version number in debian/changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-indicator-kdeconnect (0.9.3) precise; urgency=low
+indicator-kdeconnect (0.9.4) precise; urgency=low
   * Add Languages: Greek, Hebrew, Chinese
   * Fix Icons Name
 


### PR DESCRIPTION
The latest version in the changelog was incorrectly reusing the
previous version number. The corresponding release tag referred
to this release as 0.9.4.

This fixes two Lintian warnings:
- latest-debian-changelog-entry-reuses-existing-version
- latest-debian-changelog-entry-without-new-version