### PR TITLE
Fix inconsistent licensing information

### DIFF
--- a/data/configs/com.indicator-kdeconnect.appdata.xml
+++ b/data/configs/com.indicator-kdeconnect.appdata.xml
@@ -2,7 +2,7 @@
 <component type="desktop">
   <id>com.indicator-kdeconnect.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-2.1+</project_license>
+  <project_license>LGPL-2.1+</project_license>
   <name>Indicator-KDEConnect</name>
   <summary>
     AppIndicator for KDE Connect

--- a/debian/copyright
+++ b/debian/copyright
@@ -5,21 +5,38 @@ Source: https://github.com/Bajoja/indicator-kdeconnect
 Files: *
 Copyright: 2013 Viko Adi Rahmawan
            2016 Bajoja
-License: GPL-3.0+
+License: LGPL-2.1+
 
-License: GPL-3.0+
- This program is free software: you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation, either version 3 of the License, or
- (at your option) any later version.
+Files: data/configs/com.indicator-kdeconnect.appdata.xml
+Copyright: 2018 Bajoja
+License: CC0-1.0
+
+License: LGPL-2.1+
+ This package is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
  .
  This package is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
  .
- You should have received a copy of the GNU General Public License
- along with this program. If not, see <http://www.gnu.org/licenses/>.
+ You should have received a copy of the GNU Lesser General Public
+ License along with this package; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
  .
- On Debian systems, the complete text of the GNU General
- Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
+ On Debian systems, the complete text of the GNU Lesser General
+ Public License can be found in `/usr/share/common-licenses/LGPL-2.1'.
+
+License: CC0-1.0
+ The person who associated a work with this deed has dedicated the work to the
+ public domain by waiving all of his or her rights to the work worldwide under
+ copyright law, including all related and neighboring rights, to the extent
+ allowed by law.
+ .
+ You can copy, modify, distribute and perform the work, even for commercial
+ purposes, all without asking permission. See Other Information below.
+ .
+ On Debian systems, the complete text of the CC0 1.0 Universal (CC0 1.0) Public
+ Domain Dedication can be found in `/usr/share/common-licenses/CC0-1.0'.


### PR DESCRIPTION
The project's primary license wasn't properly reflected in the app's
metadata, nor in the Debian package's copyright file. Additionally,
the metadata itself is licensed differently, a fact that wasn't
reflected in the package's copyright file.

Closes #161