### PR TITLE
Remove language extension from installed script

### DIFF
--- a/meson_post_install.py
+++ b/meson_post_install.py
@@ -6,7 +6,7 @@ import subprocess
 schemadir = os.path.join(os.environ['MESON_INSTALL_PREFIX'], 'share', 'glib-2.0', 'schemas')
 bindir = os.path.join(os.environ['MESON_INSTALL_PREFIX'], 'bin', 'indicator-kdeconnect')
 libdir = os.path.join(os.environ['MESON_INSTALL_PREFIX'], 'lib', 'libindicator-kdeconnect.so')
-smsdir = os.path.join(os.environ['MESON_INSTALL_PREFIX'], 'bin', 'sms.py')
+smsdir = os.path.join(os.environ['MESON_INSTALL_PREFIX'], 'bin', 'sms')
 
 if not os.environ.get('DESTDIR'):
 	print('Compiling indicator-kdeconnect schemas on '+schemadir+'...')
@@ -15,7 +15,7 @@ if not os.environ.get('DESTDIR'):
 	subprocess.call(['ln', bindir, '/lib'])
 	print('Linking libindicator-kdeconnect.so '+libdir+'...')
 	subprocess.call(['ln', libdir, '/bin'])
-	print('Linking sms.py '+smsdir+'...')
+	print('Linking sms '+smsdir+'...')
 	subprocess.call(['ln', smsdir, '/bin'])
-	print('Execution permition sms.py '+smsdir+'...')
+	print('Execution permition sms '+smsdir+'...')
 	subprocess.call(['chmod', '+x', smsdir])

--- a/src/common/meson.build
+++ b/src/common/meson.build
@@ -18,7 +18,7 @@ indicator_kdeconnect_conf.set_quoted('IKCS_APPLICATION_ID', 'com.indicator-kdeco
 indicator_kdeconnect_conf.set_quoted('TELEPHONY_CONTACTS', '/indicator-kdeconnect/sms/contacts.json')
 indicator_kdeconnect_conf.set_quoted('TELEPHONY_SMS_TOKEN', '/indicator-kdeconnect/sms/token.json')
 indicator_kdeconnect_conf.set_quoted('PACKAGE_SETTINGS', meson.project_name() + ' -s')
-indicator_kdeconnect_conf.set_quoted('SMS_APPLICATION_ID', join_paths(get_option('bindir'), 'sms.py'))
+indicator_kdeconnect_conf.set_quoted('SMS_APPLICATION_ID', join_paths(get_option('bindir'), 'sms'))
 
 
 configure_file(output: 'config-header.vala',

--- a/src/extensions/sms/meson.build
+++ b/src/extensions/sms/meson.build
@@ -1,6 +1,7 @@
 # Executable type
 
 install_data('sms.py', 
+             rename: 'sms',
              install_dir: get_option('bindir'))  
 
-#run_command('chmod', '+x', join_paths(get_option('bindir'), 'sms.py'))                                     
+#run_command('chmod', '+x', join_paths(get_option('bindir'), 'sms'))


### PR DESCRIPTION
The script sms.py was installed into /usr/bin with the language
extension (.py) intact. It is unconventional to leave the language
extension; the script should typically be renamed before or during
installation.

Closes #162