### PR TITLE
Require --device when invoking sms

### DIFF
--- a/src/extensions/sms/sms.py
+++ b/src/extensions/sms/sms.py
@@ -33,7 +33,7 @@ gettext.textdomain('indicator-kdeconnect')
 parser = argparse.ArgumentParser(
 	description='Send sms via KDE Connect with Google Contacts sync and '
 	+ 'autocomplete')
-parser.add_argument('-d', '--device', help='connected device id')
+parser.add_argument('-d', '--device', help='connected device id', required=True)
 args = parser.parse_args()
 
 data_dir = os.path.expanduser('~/.local/share/indicator-kdeconnect/sms')


### PR DESCRIPTION
The 'sms' program needs the device ID to run. Prior to this change,
omitting the --device option crashes the program. Even if the error
had been otherwise handled, the text message still couldn't have been
sent without a device ID.