### PR TITLE
Differentiate the two desktop entries

### DIFF
--- a/data/desktop/indicator-kdeconnect-settings.desktop.in
+++ b/data/desktop/indicator-kdeconnect-settings.desktop.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=KDE Connect Indicator
+Name=KDE Connect Indicator Settings
 Comment=An awesome system for Desktop-Phone continuity.
 Exec=indicator-kdeconnect -s
 Terminal=false


### PR DESCRIPTION
The regular desktop entry and the settings entry are identical when
listed in desktop menus. By clearly labeling the settings entry,
the desired action can be more easily selected.